### PR TITLE
Optionally set approval:manual on first stage of PR pipelines (#3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'cd.go.plugin.config.yaml'
-version "0.13.2-adn.3"
+version "0.13.2-adn.4"
 
 apply plugin: 'java'
 apply plugin: "com.github.jk1.dependency-license-report"

--- a/src/main/java/cd/go/plugin/config/yaml/JSONUtils.java
+++ b/src/main/java/cd/go/plugin/config/yaml/JSONUtils.java
@@ -1,10 +1,14 @@
 package cd.go.plugin.config.yaml;
 
-import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
-
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
 
 public class JSONUtils {
     static <T> T fromJSON(String json) {
@@ -45,5 +49,14 @@ public class JSONUtils {
             throw new YamlConfigException("field " + yamlFieldName + ": is required");
 
         dest.put(yamlFieldName, value);
+    }
+
+    public static Stream<JsonElement> stream(JsonArray array) {
+        return StreamSupport.stream(array.spliterator(), false);
+    }
+
+    public static String getKeyAsString(JsonElement element, String key) {
+        JsonElement value = element.getAsJsonObject().get(key);
+        return value != null ? value.getAsString() : null;
     }
 }

--- a/src/main/java/cd/go/plugin/config/yaml/PluginSettings.java
+++ b/src/main/java/cd/go/plugin/config/yaml/PluginSettings.java
@@ -7,11 +7,20 @@ class PluginSettings {
     static final String DEFAULT_FILE_PATTERN = "**/*.gocd.yaml,**/*.gocd.yml";
     static final String DEFAULT_DEFAULT_AUTO_UPDATE = "";
 
+    static final String DEFAULT_USE_APPROVAL_MANUAL_FOR_PRS = "false";
+
+    static final String DEFAULT_PR_MATERIAL_ID_PATTERN = null;
+
     static final String PLUGIN_SETTINGS_DEFAULT_AUTO_UPDATE = "default_auto_update";
+
+    static final String PLUGIN_SETTINGS_USE_APPROVAL_MANUAL_FOR_PRS = "use_approval_manual_for_prs";
+    static final String PLUGIN_SETTINGS_PR_MATERIAL_ID_PATTERN = "pr_material_id_pattern";
 
     private String filePattern;
 
     private Boolean defaultGitAutoUpdate;
+    private boolean useApprovalManualForPRs;
+    private String prMaterialIdPattern;
 
     PluginSettings() {
     }
@@ -23,10 +32,15 @@ class PluginSettings {
     static PluginSettings fromJson(String json) {
         Map<String, String> raw = JSONUtils.fromJSON(json);
         PluginSettings settings = new PluginSettings();
+
         settings.filePattern = raw.get(PLUGIN_SETTINGS_FILE_PATTERN);
+
         String defaultAutoUpdateVal = raw.get(PLUGIN_SETTINGS_DEFAULT_AUTO_UPDATE);
         settings.defaultGitAutoUpdate = defaultAutoUpdateVal == null || defaultAutoUpdateVal.isBlank() ? null :
                 Boolean.valueOf(defaultAutoUpdateVal);
+
+        settings.useApprovalManualForPRs = Boolean.parseBoolean(raw.get(PLUGIN_SETTINGS_USE_APPROVAL_MANUAL_FOR_PRS));
+        settings.prMaterialIdPattern = raw.get(PLUGIN_SETTINGS_PR_MATERIAL_ID_PATTERN);
 
         return settings;
     }
@@ -37,5 +51,13 @@ class PluginSettings {
 
     Boolean getDefaultGitAutoUpdate() {
         return defaultGitAutoUpdate;
+    }
+
+    boolean useApprovalManualForPRs() {
+        return useApprovalManualForPRs;
+    }
+
+    String getPrMaterialIdPattern() {
+        return prMaterialIdPattern;
     }
 }

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -1,7 +1,33 @@
 package cd.go.plugin.config.yaml;
 
-import cd.go.plugin.config.yaml.transforms.RootTransform;
+import static cd.go.plugin.config.yaml.PluginSettings.DEFAULT_DEFAULT_AUTO_UPDATE;
+import static cd.go.plugin.config.yaml.PluginSettings.DEFAULT_FILE_PATTERN;
+import static cd.go.plugin.config.yaml.PluginSettings.DEFAULT_USE_APPROVAL_MANUAL_FOR_PRS;
+import static cd.go.plugin.config.yaml.PluginSettings.DEFAULT_PR_MATERIAL_ID_PATTERN;
+import static cd.go.plugin.config.yaml.PluginSettings.PLUGIN_SETTINGS_DEFAULT_AUTO_UPDATE;
+import static cd.go.plugin.config.yaml.PluginSettings.PLUGIN_SETTINGS_FILE_PATTERN;
+import static cd.go.plugin.config.yaml.PluginSettings.PLUGIN_SETTINGS_USE_APPROVAL_MANUAL_FOR_PRS;
+import static cd.go.plugin.config.yaml.PluginSettings.PLUGIN_SETTINGS_PR_MATERIAL_ID_PATTERN;
+import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE;
+import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.badRequest;
+import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.error;
+import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.success;
+import static java.lang.String.format;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
 import cd.go.plugin.config.yaml.transforms.DefaultOverrides;
+import cd.go.plugin.config.yaml.transforms.RootTransform;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
@@ -17,23 +43,14 @@ import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import org.apache.commons.io.IOUtils;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
-import java.util.function.Supplier;
-
-import static cd.go.plugin.config.yaml.PluginSettings.DEFAULT_DEFAULT_AUTO_UPDATE;
-import static cd.go.plugin.config.yaml.PluginSettings.DEFAULT_FILE_PATTERN;
-import static cd.go.plugin.config.yaml.PluginSettings.PLUGIN_SETTINGS_DEFAULT_AUTO_UPDATE;
-import static cd.go.plugin.config.yaml.PluginSettings.PLUGIN_SETTINGS_FILE_PATTERN;
-import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.*;
-import static java.lang.String.format;
-
 @Extension
 public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
     private static final String DISPLAY_NAME_FILE_PATTERN = "Go YAML files pattern";
     private static final String DISPLAY_NAME_DEFAULT_AUTO_UPDATE = "Default auto_update for Git materials";
+
+    private static final String DISPLAY_NAME_USE_APPROVAL_MANUAL_FOR_PRS = "Set approval: manual on PR pipelines";
+
+    private static final String DISPLAY_NAME_PR_MATERIAL_ID_PATTERN = "Regex pattern to identify PR materials by their ID";
     private static final String PLUGIN_ID = "yaml.config.plugin.adn";
     private static Logger LOGGER = Logger.getLoggerFor(YamlConfigPlugin.class);
 
@@ -121,6 +138,8 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
             settings = fetchPluginSettings();
         }
         DefaultOverrides.setDefaultGitAutoUpdate(settings.getDefaultGitAutoUpdate());
+        DefaultOverrides.setUseApprovalManualForPRs(settings.useApprovalManualForPRs());
+        DefaultOverrides.setPrMaterialIdPattern(settings.getPrMaterialIdPattern());
     }
 
     private GoPluginApiResponse handleParseContentRequest(GoPluginApiRequest request) {
@@ -212,6 +231,10 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
         response.put(PLUGIN_SETTINGS_FILE_PATTERN, createField(DISPLAY_NAME_FILE_PATTERN, DEFAULT_FILE_PATTERN, false, false, "0"));
         response.put(PLUGIN_SETTINGS_DEFAULT_AUTO_UPDATE, createField(DISPLAY_NAME_DEFAULT_AUTO_UPDATE,
                 DEFAULT_DEFAULT_AUTO_UPDATE, false, false, "1"));
+        response.put(PLUGIN_SETTINGS_USE_APPROVAL_MANUAL_FOR_PRS, createField(DISPLAY_NAME_USE_APPROVAL_MANUAL_FOR_PRS,
+                DEFAULT_USE_APPROVAL_MANUAL_FOR_PRS, false, false, "2"));
+        response.put(PLUGIN_SETTINGS_PR_MATERIAL_ID_PATTERN, createField(DISPLAY_NAME_PR_MATERIAL_ID_PATTERN,
+                DEFAULT_PR_MATERIAL_ID_PATTERN, false, false, "3"));
         return success(gson.toJson(response));
     }
 

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/DefaultOverrides.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/DefaultOverrides.java
@@ -4,20 +4,42 @@
 
 package cd.go.plugin.config.yaml.transforms;
 
+import static cd.go.plugin.config.yaml.JSONUtils.getKeyAsString;
 import static cd.go.plugin.config.yaml.transforms.MaterialTransform.JSON_MATERIAL_AUTO_UPDATE_FIELD;
 import static cd.go.plugin.config.yaml.transforms.MaterialTransform.JSON_MATERIAL_TYPE_FIELD;
 import static cd.go.plugin.config.yaml.transforms.MaterialTransform.YAML_MATERIAL_AUTO_UPDATE_FIELD;
 import static cd.go.plugin.config.yaml.transforms.MaterialTransform.YAML_SHORT_KEYWORD_GIT;
+import static cd.go.plugin.config.yaml.transforms.MaterialTransform.YAML_SHORT_KEYWORD_SCM_ID;
+import static cd.go.plugin.config.yaml.transforms.PipelineTransform.JSON_PIPELINE_MATERIALS_FIELD;
+import static cd.go.plugin.config.yaml.transforms.PipelineTransform.JSON_PIPELINE_STAGES_FIELD;
+import static cd.go.plugin.config.yaml.transforms.PipelineTransform.YAML_PIPELINE_MATERIALS_FIELD;
+import static cd.go.plugin.config.yaml.transforms.PipelineTransform.YAML_PIPELINE_STAGES_FIELD;
+import static cd.go.plugin.config.yaml.transforms.StageTransform.JSON_STAGE_APPROVAL_FIELD;
+import static cd.go.plugin.config.yaml.transforms.StageTransform.JSON_STAGE_APPROVAL_TYPE_FIELD;
+import static cd.go.plugin.config.yaml.transforms.StageTransform.YAML_STAGE_APPROVAL_TYPE_FIELD;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
 
+import cd.go.plugin.config.yaml.JSONUtils;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 public class DefaultOverrides {
 
 	private static final ThreadLocal<DefaultOverrides> SINGLETON = new ThreadLocal<>();
 
+	// null = not set, don't use a default
+	// true = set auto_update to true by default
+	// false = set auto_update to false by default
 	private Boolean defaultGitAutoUpdate = null;
+
+	private boolean useApprovalManualForPRs = false;
+
+	private String prMaterialIdPattern = null;
 
 	public static DefaultOverrides getInstance() {
 		if (SINGLETON.get() == null) {
@@ -32,6 +54,22 @@ public class DefaultOverrides {
 
 	public static Boolean getDefaultGitAutoUpdate() {
 		return getInstance().defaultGitAutoUpdate;
+	}
+
+	public static boolean useApprovalManualForPRs() {
+		return getInstance().useApprovalManualForPRs;
+	}
+
+	public static void setUseApprovalManualForPRs(boolean useApprovalManualForPRs) {
+		getInstance().useApprovalManualForPRs = useApprovalManualForPRs;
+	}
+
+	public static void setPrMaterialIdPattern(String prMaterialIdPattern) {
+		getInstance().prMaterialIdPattern = prMaterialIdPattern;
+	}
+
+	public static String getPrMaterialIdPattern() {
+		return getInstance().prMaterialIdPattern;
 	}
 
 	public static void overrideGitMaterialAutoUpdate(JsonObject jsonOutput) {
@@ -50,5 +88,79 @@ public class DefaultOverrides {
 				yamlOutput.remove(YAML_MATERIAL_AUTO_UPDATE_FIELD);
 			}
 		}
+	}
+
+	public static void addApprovalManualForPullRequests(JsonObject pipeline) {
+		if (!isApprovalManualForPRsFullyConfigured()) {
+			return;
+		}
+
+		JsonArray materials = pipeline.getAsJsonArray(JSON_PIPELINE_MATERIALS_FIELD);
+		if (materials == null) {
+			return;
+		}
+
+		boolean hasPRMaterials = JSONUtils.stream(materials).anyMatch(DefaultOverrides::isPRMaterial);
+		if (!hasPRMaterials) {
+			return;
+		}
+
+		JsonArray stages = pipeline.getAsJsonArray(JSON_PIPELINE_STAGES_FIELD);
+		if (stages == null || stages.size() == 0) {
+			return;
+		}
+		JsonObject firstStage = stages.get(0).getAsJsonObject();
+		if (firstStage.has("approval")) {
+			return;
+		}
+		JsonObject approvalJson = new JsonObject();
+		approvalJson.addProperty(JSON_STAGE_APPROVAL_TYPE_FIELD, "manual");
+		firstStage.add(JSON_STAGE_APPROVAL_FIELD, approvalJson);
+	}
+
+	public static void addApprovalManualForPullRequestsInverse(Map<String, Object> pipeline) {
+		if (!isApprovalManualForPRsFullyConfigured()) {
+			return;
+		}
+
+		Map<String, Map<String, Object>> materials =
+				(Map<String, Map<String, Object>>) pipeline.get(YAML_PIPELINE_MATERIALS_FIELD);
+		if (materials == null) {
+			return;
+		}
+
+		boolean hasPRMaterials = materials.values().stream().anyMatch(DefaultOverrides::isPRMaterial);
+		if (!hasPRMaterials) {
+			return;
+		}
+
+		List<Map<String, Object>> stages = (List<Map<String, Object>>) pipeline.get(YAML_PIPELINE_STAGES_FIELD);
+		if (stages == null || stages.isEmpty()) {
+			return;
+		}
+		Map<String, Object> firstStage = (Map<String, Object>) stages.get(0).values().iterator().next();
+
+		Map<String, Object> approval = (Map<String, Object>) firstStage.get("approval");
+		if (approval != null && Objects.equals(approval.get(YAML_STAGE_APPROVAL_TYPE_FIELD), "manual")) {
+			firstStage.remove("approval");
+		}
+	}
+
+	private static boolean isApprovalManualForPRsFullyConfigured() {
+		return useApprovalManualForPRs() && getPrMaterialIdPattern() != null && !getPrMaterialIdPattern().isBlank();
+	}
+
+	private static boolean isPRMaterial(JsonElement material) {
+		if (!material.isJsonObject() || !Objects.equals(getKeyAsString(material, JSON_MATERIAL_TYPE_FIELD), "plugin")) {
+			return false;
+		}
+
+		String scmId = getKeyAsString(material, "scm_id");
+		return scmId != null && Pattern.matches(getPrMaterialIdPattern(), scmId);
+	}
+
+	private static boolean isPRMaterial(Map<String, Object> material) {
+		String scmId = (String) material.get(YAML_SHORT_KEYWORD_SCM_ID);
+		return scmId != null && Pattern.matches(getPrMaterialIdPattern(), scmId);
 	}
 }

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/MaterialTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/MaterialTransform.java
@@ -1,17 +1,20 @@
 package cd.go.plugin.config.yaml.transforms;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.internal.LinkedTreeMap;
+import static cd.go.plugin.config.yaml.JSONUtils.addOptionalValue;
+import static cd.go.plugin.config.yaml.YamlUtils.addOptionalBoolean;
+import static cd.go.plugin.config.yaml.YamlUtils.addOptionalObject;
+import static cd.go.plugin.config.yaml.YamlUtils.addOptionalString;
+import static cd.go.plugin.config.yaml.YamlUtils.getOptionalString;
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import static cd.go.plugin.config.yaml.JSONUtils.addOptionalValue;
-import static cd.go.plugin.config.yaml.YamlUtils.*;
-import static java.lang.String.format;
-import static java.util.UUID.randomUUID;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.internal.LinkedTreeMap;
 
 public class MaterialTransform extends ConfigurationTransform {
 
@@ -31,7 +34,7 @@ public class MaterialTransform extends ConfigurationTransform {
 
     public static final String YAML_BLACKLIST_KEYWORD = "blacklist";
     private static final String YAML_SHORT_KEYWORD_DEPENDENCY = "pipeline";
-    private static final String YAML_SHORT_KEYWORD_SCM_ID = "scm";
+    public static final String YAML_SHORT_KEYWORD_SCM_ID = "scm";
     private static final String YAML_SHORT_KEYWORD_PACKAGE_ID = "package";
     private static final String YAML_SHORT_KEYWORD_SVN = "svn";
     private static final String JSON_MATERIAL_CHECK_EXTERNALS_FIELD = "check_externals";

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/PipelineTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/PipelineTransform.java
@@ -1,19 +1,23 @@
 package cd.go.plugin.config.yaml.transforms;
 
-import cd.go.plugin.config.yaml.YamlConfigException;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.internal.LinkedTreeMap;
+import static cd.go.plugin.config.yaml.JSONUtils.addOptionalInt;
+import static cd.go.plugin.config.yaml.JSONUtils.addOptionalValue;
+import static cd.go.plugin.config.yaml.YamlUtils.addOptionalBoolean;
+import static cd.go.plugin.config.yaml.YamlUtils.addOptionalInteger;
+import static cd.go.plugin.config.yaml.YamlUtils.addOptionalObject;
+import static cd.go.plugin.config.yaml.YamlUtils.addOptionalString;
+import static cd.go.plugin.config.yaml.YamlUtils.addRequiredString;
+import static cd.go.plugin.config.yaml.transforms.EnvironmentVariablesTransform.JSON_ENV_VAR_FIELD;
+import static cd.go.plugin.config.yaml.transforms.ParameterTransform.YAML_PIPELINE_PARAMETERS_FIELD;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static cd.go.plugin.config.yaml.JSONUtils.addOptionalInt;
-import static cd.go.plugin.config.yaml.JSONUtils.addOptionalValue;
-import static cd.go.plugin.config.yaml.YamlUtils.*;
-import static cd.go.plugin.config.yaml.transforms.EnvironmentVariablesTransform.JSON_ENV_VAR_FIELD;
-import static cd.go.plugin.config.yaml.transforms.ParameterTransform.YAML_PIPELINE_PARAMETERS_FIELD;
+import cd.go.plugin.config.yaml.YamlConfigException;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.internal.LinkedTreeMap;
 
 public class PipelineTransform {
     private static final String JSON_PIPELINE_NAME_FIELD = "name";
@@ -24,8 +28,8 @@ public class PipelineTransform {
     private static final String JSON_PIPELINE_LOCK_BEHAVIOR_FIELD = "lock_behavior";
     private static final String JSON_PIPELINE_TRACKING_TOOL_FIELD = "tracking_tool";
     private static final String JSON_PIPELINE_TIMER_FIELD = "timer";
-    private static final String JSON_PIPELINE_MATERIALS_FIELD = "materials";
-    private static final String JSON_PIPELINE_STAGES_FIELD = "stages";
+    public static final String JSON_PIPELINE_MATERIALS_FIELD = "materials";
+    public static final String JSON_PIPELINE_STAGES_FIELD = "stages";
     private static final String JSON_PIPELINE_DISPLAY_ORDER_FIELD = "display_order_weight";
 
     private static final String YAML_PIPELINE_GROUP_FIELD = "group";
@@ -35,8 +39,8 @@ public class PipelineTransform {
     private static final String YAML_PIPELINE_LOCK_BEHAVIOR_FIELD = "lock_behavior";
     private static final String YAML_PIPELINE_TRACKING_TOOL_FIELD = "tracking_tool";
     private static final String YAML_PIPELINE_TIMER_FIELD = "timer";
-    private static final String YAML_PIPELINE_MATERIALS_FIELD = "materials";
-    private static final String YAML_PIPELINE_STAGES_FIELD = "stages";
+    public static final String YAML_PIPELINE_MATERIALS_FIELD = "materials";
+    public static final String YAML_PIPELINE_STAGES_FIELD = "stages";
     private static final String YAML_PIPELINE_DISPLAY_ORDER_FIELD = "display_order";
 
     private final MaterialTransform materialTransform;
@@ -89,6 +93,8 @@ public class PipelineTransform {
             pipeline.add(YAML_PIPELINE_PARAMETERS_FIELD, params);
         }
 
+        DefaultOverrides.addApprovalManualForPullRequests(pipeline);
+
         return pipeline;
     }
 
@@ -124,6 +130,8 @@ public class PipelineTransform {
         if (params != null && !params.isEmpty()) {
             pipelineMap.putAll(params);
         }
+
+        DefaultOverrides.addApprovalManualForPullRequestsInverse(pipelineMap);
 
         result.put(name, pipelineMap);
         return result;

--- a/src/main/java/cd/go/plugin/config/yaml/transforms/StageTransform.java
+++ b/src/main/java/cd/go/plugin/config/yaml/transforms/StageTransform.java
@@ -1,16 +1,20 @@
 package cd.go.plugin.config.yaml.transforms;
 
-import cd.go.plugin.config.yaml.YamlConfigException;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.internal.LinkedTreeMap;
+import static cd.go.plugin.config.yaml.JSONUtils.addOptionalList;
+import static cd.go.plugin.config.yaml.JSONUtils.addOptionalValue;
+import static cd.go.plugin.config.yaml.JSONUtils.addRequiredValue;
+import static cd.go.plugin.config.yaml.YamlUtils.addOptionalBoolean;
+import static cd.go.plugin.config.yaml.YamlUtils.addOptionalStringList;
+import static cd.go.plugin.config.yaml.YamlUtils.addRequiredString;
+import static cd.go.plugin.config.yaml.transforms.EnvironmentVariablesTransform.JSON_ENV_VAR_FIELD;
 
 import java.util.List;
 import java.util.Map;
 
-import static cd.go.plugin.config.yaml.JSONUtils.*;
-import static cd.go.plugin.config.yaml.YamlUtils.*;
-import static cd.go.plugin.config.yaml.transforms.EnvironmentVariablesTransform.JSON_ENV_VAR_FIELD;
+import cd.go.plugin.config.yaml.YamlConfigException;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.internal.LinkedTreeMap;
 
 public class StageTransform {
     private static final String JSON_STAGE_NAME_FIELD = "name";
@@ -21,9 +25,9 @@ public class StageTransform {
     private static final String JSON_STAGE_CLEAN_WORK_FIELD = "clean_working_directory";
     private static final String YAML_STAGE_CLEAN_WORK_FIELD = "clean_workspace";
     private static final String YAML_STAGE_APPROVAL_FIELD = "approval";
-    private static final String JSON_STAGE_APPROVAL_FIELD = "approval";
-    private static final String JSON_STAGE_APPROVAL_TYPE_FIELD = "type";
-    private static final String YAML_STAGE_APPROVAL_TYPE_FIELD = "type";
+    public static final String JSON_STAGE_APPROVAL_FIELD = "approval";
+    public static final String JSON_STAGE_APPROVAL_TYPE_FIELD = "type";
+    public static final String YAML_STAGE_APPROVAL_TYPE_FIELD = "type";
     private static final String JSON_STAGE_JOBS_FIELD = "jobs";
     private static final String JSON_STAGE_APPROVAL_ALLOW_ONLY_ON_SUCCESS_FIELD = "allow_only_on_success";
     private static final String YAML_STAGE_APPROVAL_ALLOW_ONLY_ON_SUCCESS_FIELD = "allow_only_on_success";

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -2,6 +2,7 @@
     <label>GoCD YAML files global pattern:</label>
     <input type="text" ng-model="file_pattern" ng-required="false" placeholder="**/*.gocd.yaml,**/*.gocd.yml" />
     <span class="form_error" ng-show="GOINPUTNAME[file_pattern].$error.server">{{ GOINPUTNAME[file_pattern].$error.server }}</span>
+
     <label>Default auto_update for Git materials:</label>
     <select ng-model="default_auto_update" ng-required="false" >
         <option value="">Not set</option>
@@ -9,4 +10,13 @@
         <option value="false">false</option>
     </select>
     <span class="form_error" ng-show="GOINPUTNAME[default_auto_update].$error.server">{{ GOINPUTNAME[default_auto_update].$error.server }}</span>
+
+    <br/>
+    <input type="checkbox" ng-model="use_approval_manual_for_prs" ng-required="false" ng-true-value="true" ng-false-value="false"/>
+    <label>Set approval: manual on PR pipelines</label>
+    <span class="form_error" ng-show="GOINPUTNAME[use_approval_manual_for_prs].$error.server">{{ GOINPUTNAME[use_approval_manual_for_prs].$error.server }}</span>
+
+    <label>Regex pattern to identify PR materials by their ID:</label>
+    <input type="text" ng-model="pr_material_id_pattern" ng-required="false" placeholder="" />
+    <span class="form_error" ng-show="GOINPUTNAME[pr_material_id_pattern].$error.server">{{ GOINPUTNAME[pr_material_id_pattern].$error.server }}</span>
 </div>

--- a/src/test/java/cd/go/plugin/config/yaml/transforms/PipelineTransformIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/transforms/PipelineTransformIntegrationTest.java
@@ -1,0 +1,109 @@
+package cd.go.plugin.config.yaml.transforms;
+
+import static cd.go.plugin.config.yaml.TestUtils.assertYamlEquivalent;
+import static cd.go.plugin.config.yaml.TestUtils.loadString;
+import static cd.go.plugin.config.yaml.TestUtils.readJsonGson;
+import static cd.go.plugin.config.yaml.TestUtils.readJsonObject;
+import static cd.go.plugin.config.yaml.TestUtils.readYamlObject;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import cd.go.plugin.config.yaml.JsonObjectMatcher;
+import cd.go.plugin.config.yaml.YamlUtils;
+import com.google.gson.JsonObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PipelineTransformIntegrationTest {
+
+    private PipelineTransform parser;
+
+    @Before
+    public void setUp() {
+        EnvironmentVariablesTransform environmentTransform = new EnvironmentVariablesTransform();
+
+        parser = new PipelineTransform(
+                new MaterialTransform(),
+                new StageTransform(environmentTransform, new JobTransform(environmentTransform, new TaskTransform())),
+                environmentTransform,
+                new ParameterTransform());
+    }
+
+    @After
+    public void cleanUp() {
+        DefaultOverrides.setUseApprovalManualForPRs(false);
+        DefaultOverrides.setPrMaterialIdPattern(null);
+    }
+
+    @Test
+    public void shouldAddApprovalManualToPRPipelines() throws IOException {
+        DefaultOverrides.setUseApprovalManualForPRs(true);
+        DefaultOverrides.setPrMaterialIdPattern("^.*\\.pr$");
+
+        testTransform("pullrequest.pipe");
+    }
+
+    @Test
+    public void shouldAddApprovalManualToPRPipelines_Inverse() throws IOException {
+        DefaultOverrides.setUseApprovalManualForPRs(true);
+        DefaultOverrides.setPrMaterialIdPattern("^.*\\.pr$");
+
+        testInverseTransform("pullrequest.pipe");
+    }
+
+    @Test
+    public void shouldNotAddApprovalManualIfOtherSCM() throws IOException {
+        DefaultOverrides.setUseApprovalManualForPRs(true);
+        DefaultOverrides.setPrMaterialIdPattern("not-matching-pattern");
+
+        testTransform("pullrequest.pipe", "pullrequest-no-approval.pipe");
+    }
+
+    @Test
+    public void shouldNotAddApprovalManualIfOtherSCM_Inverse() throws IOException {
+        DefaultOverrides.setUseApprovalManualForPRs(true);
+        DefaultOverrides.setPrMaterialIdPattern("not-matching-pattern");
+
+        testInverseTransform("pullrequest-no-approval.pipe", "pullrequest.pipe");
+    }
+
+    @Test
+    public void shouldNotAddApprovalManualIfExplicitApproval() throws IOException {
+        DefaultOverrides.setUseApprovalManualForPRs(true);
+        DefaultOverrides.setPrMaterialIdPattern("^.*\\.pr$");
+
+        testTransform("explicit_approval.pipe");
+    }
+
+    @Test
+    public void shouldNotAddApprovalManualIfExplicitApproval_Inverse() throws IOException {
+        DefaultOverrides.setUseApprovalManualForPRs(true);
+        DefaultOverrides.setPrMaterialIdPattern("^.*\\.pr$");
+
+        testInverseTransform("explicit_approval.pipe");
+    }
+
+    private void testTransform(String caseFile) throws IOException {
+        testTransform(caseFile, caseFile);
+    }
+
+    private void testInverseTransform(String caseFile) throws IOException {
+        testInverseTransform(caseFile, caseFile);
+    }
+
+    private void testTransform(String caseFile, String expectedFile) throws IOException {
+        JsonObject expectedObject = (JsonObject) readJsonObject("parts/" + expectedFile + ".json");
+        JsonObject jsonObject = parser.transform(readYamlObject("parts/" + caseFile + ".yaml"), 9);
+        assertThat(jsonObject, is(new JsonObjectMatcher(expectedObject)));
+    }
+
+    private void testInverseTransform(String caseFile, String expectedFile) throws IOException {
+        String expectedObject = loadString("parts/" + expectedFile + ".yaml");
+        Map<String, Object> actual = parser.inverseTransform(readJsonGson("parts/" + caseFile + ".json"));
+        assertYamlEquivalent(expectedObject, YamlUtils.dump(actual));
+    }
+}

--- a/src/test/resources/examples.out/pullrequest.gocd.json
+++ b/src/test/resources/examples.out/pullrequest.gocd.json
@@ -1,0 +1,38 @@
+{
+  "target_version": 1,
+  "errors": [],
+  "environments": [],
+  "pipelines": [
+    {
+      "location": "pullrequest.gocd.yaml",
+      "name": "pipe1",
+      "group": "pullrequest",
+      "materials": [
+        {
+          "name": "pipe1-pr",
+          "type": "plugin",
+          "scm_id": "foo.bar.pr"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build",
+          "approval": {
+            "type": "manual"
+          },
+          "jobs": [
+            {
+              "name": "build",
+              "tasks": [
+                {
+                  "type": "exec",
+                  "command": "make"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/examples/pullrequest.gocd.yaml
+++ b/src/test/resources/examples/pullrequest.gocd.yaml
@@ -1,0 +1,14 @@
+# pullrequest.gocd.yaml
+pipelines:
+  pipe1:
+    group: pullrequest
+    materials:
+      pipe1-pr:
+        scm: foo.bar.pr
+    stages:
+      - build: # name of stage
+          jobs:
+            build: # name of the job
+              tasks:
+               - exec: # indicates type of task
+                   command: make

--- a/src/test/resources/parts/explicit_approval.pipe.json
+++ b/src/test/resources/parts/explicit_approval.pipe.json
@@ -1,0 +1,44 @@
+{
+	"name": "pipe1",
+	"group": "mygroup",
+	"materials": [
+		{
+			"name": "pipe1-pr",
+			"type": "plugin",
+			"scm_id": "foo.bar.pr"
+		}
+	],
+	"stages": [
+		{
+			"name": "build",
+			"approval": {
+				"type": "success"
+			},
+			"jobs": [
+				{
+					"name": "build",
+					"tasks": [
+						{
+							"type": "exec",
+							"command": "make"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "test",
+			"jobs": [
+				{
+					"name": "build",
+					"tasks": [
+						{
+							"type": "exec",
+							"command": "make"
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/test/resources/parts/explicit_approval.pipe.yaml
+++ b/src/test/resources/parts/explicit_approval.pipe.yaml
@@ -1,0 +1,21 @@
+# pipeline with explicit approval -> should not be changed
+pipe1:
+  group: mygroup
+  materials:
+    pipe1-pr:
+      scm: foo.bar.pr
+  stages:
+    - build:
+        approval:
+          type: success
+        jobs:
+          build:
+            tasks:
+              - exec:
+                  command: make
+    - test:
+        jobs:
+          build:
+            tasks:
+              - exec:
+                  command: make

--- a/src/test/resources/parts/pullrequest-no-approval.pipe.json
+++ b/src/test/resources/parts/pullrequest-no-approval.pipe.json
@@ -1,0 +1,41 @@
+{
+	"name": "pipe1",
+	"group": "mygroup",
+	"materials": [
+		{
+			"name": "pipe1-pr",
+			"type": "plugin",
+			"scm_id": "foo.bar.pr"
+		}
+	],
+	"stages": [
+		{
+			"name": "build",
+			"jobs": [
+				{
+					"name": "build",
+					"tasks": [
+						{
+							"type": "exec",
+							"command": "make"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "test",
+			"jobs": [
+				{
+					"name": "build",
+					"tasks": [
+						{
+							"type": "exec",
+							"command": "make"
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/test/resources/parts/pullrequest.pipe.json
+++ b/src/test/resources/parts/pullrequest.pipe.json
@@ -1,0 +1,44 @@
+{
+	"name": "pipe1",
+	"group": "mygroup",
+	"materials": [
+		{
+			"name": "pipe1-pr",
+			"type": "plugin",
+			"scm_id": "foo.bar.pr"
+		}
+	],
+	"stages": [
+		{
+			"name": "build",
+			"approval": {
+				"type": "manual"
+			},
+			"jobs": [
+				{
+					"name": "build",
+					"tasks": [
+						{
+							"type": "exec",
+							"command": "make"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "test",
+			"jobs": [
+				{
+					"name": "build",
+					"tasks": [
+						{
+							"type": "exec",
+							"command": "make"
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/test/resources/parts/pullrequest.pipe.yaml
+++ b/src/test/resources/parts/pullrequest.pipe.yaml
@@ -1,0 +1,19 @@
+# pipeline with a PR SCM -> should get approval: manual on first stage
+pipe1:
+  group: mygroup
+  materials:
+    pipe1-pr:
+      scm: foo.bar.pr
+  stages:
+    - build:
+        jobs:
+          build:
+            tasks:
+              - exec:
+                  command: make
+    - test:
+        jobs:
+          build:
+            tasks:
+              - exec:
+                  command: make


### PR DESCRIPTION
This change will allow us to drop the requirement for projects to set `approval: manual` on their PR pipelines. The plugin will automatically set `approval: manual` on the first stage of PR pipelines, unless the YAML config explicitly uses a different `approval` setting.

So far, we asked projects to set `approval: manual`, because there's a race condition with the dispatcher triggering PR pipelines, where GoCD will also trigger the pipeline itself, leading to two builds. The dispatcher trigger counts as a "manual" trigger, so when using `approval: manual`, only it will build and the "automatic" trigger from GoCD is ignored. This double building only happened occasionally, but now we want to change how the dispatcher triggers pipelines such that this double building would happen *every time* for projects that haven't set `approval: manual`.

With this change we can set `approval: manual` for all PR pipelines automatically and projects no longer need to set the somewhat confusing setting themselves ("wait does that mean I have to trigger my PR pipeline by hand?").

Change details:
* As in previous changes, the core logic is in `DefaultOverrides` and the changes to the original (upstream) code are kept to a minimum, so we don't diverge too much. Most of the other changes are boilerplate for plugin settings and tests.
* There are two new plugin settings: checkbox to enable this `approval: manual` feature and input box to set a regex pattern to detect which pluggable SCMs are PR materials. Unfortunately we have no other way to distinguish two different _pluggable_ materials in YAML configs, so we have to rely on our naming convention that PR materials end with `.pr`.

  ```yaml
  my-pipeline:
    materials:
      my-material:
        # there are no other fields here, so this could be any kind of pluggable material (PR, maven package, ...).
        # We can only know by the naming convention.
        scm: she.she-test.pr
  ```

For visual reference, the plugin config UI looks like this now:
![image](https://user-images.githubusercontent.com/22613301/170981769-7de812ac-04c9-4d68-a5b8-04ea56644771.png)


Fixes #3 